### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -1,4 +1,6 @@
 name: .NET CI Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rhysparry/wut.net/security/code-scanning/2](https://github.com/rhysparry/wut.net/security/code-scanning/2)

To fix this problem, you should add a `permissions:` block at the top-level of the workflow file, immediately under the `name:` or `on:` block. This will restrict the permissions of the `GITHUB_TOKEN` for all jobs in the workflow (unless jobs set more permissive job-scoped permissions). As none of the steps shown require write access, the minimal permission is usually `contents: read`. Place the following under the `name:` line and above the `on:` block:

```yaml
permissions:
  contents: read
```

This restricts jobs in the workflow to only be able to read repository contents. No additional imports, definitions, or methods are needed since this is a config change to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
