### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: pre-commit
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rhysparry/wut.net/security/code-scanning/1](https://github.com/rhysparry/wut.net/security/code-scanning/1)

To fix this error, add an explicit `permissions:` block to the workflow. The permissions block can be added at the workflow level (right after the `name:` and before `on:`) to apply to all jobs, or at the job level for a specific job. Since this workflow appears to primarily run pre-commit checks and code analysis, it likely does not need write access to repository contents. The minimal required permission is almost always `contents: read`, so add the following at the top-level (workflow level):

```yaml
permissions:
  contents: read
```

This ensures jobs receive the least privilege needed, and fully resolves the flagged CodeQL issue.

You only need to add these lines after the `name: pre-commit` line and before `on:`. No new dependencies or other definition changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
